### PR TITLE
AUT-1358 Pass id_token_hint to Keycloak logout to skip confirmation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,10 +20,12 @@ node {
     stage('Lint') {
         sh "npm run lint"
     }
-    stage('Publish') {
-        sshagent (credentials: ['bb0927b6-318c-4e4a-a3d8-ac89152185df']) {
-            sh "npm config list"
-            sh "npm publish --loglevel silly"
+    if (gitBranch == "master") {
+        stage('Publish') {
+            sshagent (credentials: ['bb0927b6-318c-4e4a-a3d8-ac89152185df']) {
+                sh "npm config list"
+                sh "npm publish --loglevel silly"
+            }
         }
     }
 }

--- a/index.js
+++ b/index.js
@@ -316,11 +316,17 @@ Keycloak.prototype.loginUrl = function (uuid, redirectUrl) {
   '&response_type=code';
 };
 
-Keycloak.prototype.logoutUrl = function (redirectUrl) {
-  return this.config.realmUrl +
-  '/protocol/openid-connect/logout' +
-  '?redirect_uri=' + encodeURIComponent(redirectUrl);
+Keycloak.prototype.logoutUrl = function (redirectUrl, idTokenHint) {
+  var url = this.config.realmUrl +
+    '/protocol/openid-connect/logout' +
+    '?redirect_uri=' + encodeURIComponent(redirectUrl);
+  if (idTokenHint) {
+    url += '&id_token_hint=' + encodeURIComponent(idTokenHint) +
+           '&client_id=' + encodeURIComponent(this.config.clientId);
+  }
+  return url;
 };
+
 
 Keycloak.prototype.accountUrl = function () {
   return this.config.realmUrl + '/account';

--- a/middleware/logout.js
+++ b/middleware/logout.js
@@ -21,17 +21,19 @@ module.exports = function (keycloak, logoutUrl) {
       return next();
     }
 
+    let host = request.hostname;
+    let headerHost = request.headers.host.split(':');
+    let port = headerHost[1] || '';
+    let redirectUrl = request.query.redirectUrl || request.protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
+
+    const idTokenHint = request.kauth.grant.id_token && request.kauth.grant.id_token.token;
+    let keycloakLogoutUrl = keycloak.logoutUrl(redirectUrl, idTokenHint);
+
     if (request.kauth.grant) {
       keycloak.deauthenticated(request);
       request.kauth.grant.unstore(request, response);
       delete request.kauth.grant;
     }
-
-    let host = request.hostname;
-    let headerHost = request.headers.host.split(':');
-    let port = headerHost[1] || '';
-    let redirectUrl = request.query.redirectUrl || request.protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
-    let keycloakLogoutUrl = keycloak.logoutUrl(redirectUrl);
 
     response.redirect(keycloakLogoutUrl);
   };

--- a/middleware/logout.js
+++ b/middleware/logout.js
@@ -26,7 +26,7 @@ module.exports = function (keycloak, logoutUrl) {
     let port = headerHost[1] || '';
     let redirectUrl = request.query.redirectUrl || request.protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
 
-    const idTokenHint = request.kauth.grant.id_token && request.kauth.grant.id_token.token;
+    const idTokenHint = request.kauth.grant && request.kauth.grant.id_token && request.kauth.grant.id_token.token;
     let keycloakLogoutUrl = keycloak.logoutUrl(redirectUrl, idTokenHint);
 
     if (request.kauth.grant) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartling/keycloak-connect",
-  "version": "3.4.42",
+  "version": "3.4.43",
   "description": "Keycloak Connect Middleware",
   "homepage": "http://keycloak.org",
   "main": "index.js",

--- a/test/unit/keycloak-object-test.js
+++ b/test/unit/keycloak-object-test.js
@@ -70,6 +70,35 @@ test('Should verify if logout URL has the configured realm.', t => {
   t.end();
 });
 
+test('Should include redirect_uri in logout URL.', t => {
+  const redirectUrl = 'http://example.com/done';
+  const url = kc.logoutUrl(redirectUrl);
+  t.equal(url.indexOf('redirect_uri=' + encodeURIComponent(redirectUrl)) > 0, true);
+  t.end();
+});
+
+test('Should not include id_token_hint or client_id when idTokenHint is omitted.', t => {
+  const url = kc.logoutUrl('http://example.com/done');
+  t.equal(url.indexOf('id_token_hint') === -1, true, 'id_token_hint should not be present');
+  t.equal(url.indexOf('client_id') === -1, true, 'client_id should not be present');
+  t.end();
+});
+
+test('Should append id_token_hint and client_id when idTokenHint is provided.', t => {
+  const idToken = 'fake.id.token';
+  const url = kc.logoutUrl('http://example.com/done', idToken);
+  t.equal(url.indexOf('id_token_hint=' + encodeURIComponent(idToken)) > 0, true, 'id_token_hint should be appended');
+  t.equal(url.indexOf('client_id=' + encodeURIComponent(kc.config.clientId)) > 0, true, 'client_id should be appended');
+  t.end();
+});
+
+test('Should treat a falsy idTokenHint the same as no hint.', t => {
+  const url = kc.logoutUrl('http://example.com/done', '');
+  t.equal(url.indexOf('id_token_hint') === -1, true, 'id_token_hint should not be present for empty string');
+  t.equal(url.indexOf('client_id') === -1, true, 'client_id should not be present for empty string');
+  t.end();
+});
+
 test('Should generate a correct UUID.', t => {
   const rgx = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
   t.equal(rgx.test(UUID()), true);

--- a/test/unit/logout-middleware-test.js
+++ b/test/unit/logout-middleware-test.js
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2016 Red Hat Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+'use strict';
+
+const test = require('tape');
+const logoutMiddleware = require('../../middleware/logout');
+
+function buildKeycloakStub () {
+  const calls = { logoutUrl: [], deauthenticated: 0 };
+  const keycloak = {
+    logoutUrl: function (redirectUrl, idTokenHint) {
+      calls.logoutUrl.push({ redirectUrl, idTokenHint });
+      return 'http://keycloak.example/logout?redirect_uri=' +
+        encodeURIComponent(redirectUrl) +
+        (idTokenHint ? '&id_token_hint=' + encodeURIComponent(idTokenHint) : '');
+    },
+    deauthenticated: function () {
+      calls.deauthenticated++;
+    }
+  };
+  return { keycloak, calls };
+}
+
+function buildRequest (overrides) {
+  const unstoreCalls = [];
+  const req = {
+    path: '/logout',
+    hostname: 'app.example',
+    protocol: 'http',
+    headers: { host: 'app.example' },
+    query: {},
+    kauth: {
+      grant: {
+        id_token: { token: 'header.payload.sig' },
+        unstore: function (request, response) {
+          unstoreCalls.push({ request, response });
+        }
+      }
+    }
+  };
+  Object.assign(req, overrides || {});
+  req._unstoreCalls = unstoreCalls;
+  return req;
+}
+
+function buildResponse () {
+  const redirects = [];
+  return {
+    redirect: function (url) {
+      redirects.push(url);
+    },
+    _redirects: redirects
+  };
+}
+
+test('logout middleware: calls next() when path does not match', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = logoutMiddleware(keycloak, '/logout');
+  const req = buildRequest({ path: '/other' });
+  const res = buildResponse();
+  let nextCalled = false;
+
+  middleware(req, res, () => { nextCalled = true; });
+
+  t.equal(nextCalled, true, 'next() should be called');
+  t.equal(calls.logoutUrl.length, 0, 'logoutUrl should not be invoked');
+  t.equal(res._redirects.length, 0, 'no redirect should occur');
+  t.end();
+});
+
+test('logout middleware: passes id_token to logoutUrl before clearing the grant', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = logoutMiddleware(keycloak, '/logout');
+  const req = buildRequest();
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(calls.logoutUrl.length, 1, 'logoutUrl invoked once');
+  t.equal(calls.logoutUrl[0].idTokenHint, 'header.payload.sig', 'id_token captured from grant before unstore');
+  t.equal(calls.deauthenticated, 1, 'deauthenticated should be invoked');
+  t.equal(req._unstoreCalls.length, 1, 'grant.unstore should be invoked');
+  t.equal(req.kauth.grant, undefined, 'grant should be removed after logout');
+  t.end();
+});
+
+test('logout middleware: does not throw when grant has no id_token', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = logoutMiddleware(keycloak, '/logout');
+  const req = buildRequest();
+  delete req.kauth.grant.id_token;
+  const res = buildResponse();
+
+  t.doesNotThrow(() => {
+    middleware(req, res, () => t.fail('next() should not be called'));
+  });
+  t.equal(calls.logoutUrl[0].idTokenHint, undefined, 'idTokenHint should be undefined when id_token is missing');
+  t.end();
+});
+
+test('logout middleware: builds redirect URL from request.protocol/hostname when no query.redirectUrl', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = logoutMiddleware(keycloak, '/logout');
+  const req = buildRequest();
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(calls.logoutUrl[0].redirectUrl, 'http://app.example/', 'default redirect URL uses protocol + hostname + /');
+  t.end();
+});
+
+test('logout middleware: includes port in default redirect URL when present in host header', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = logoutMiddleware(keycloak, '/logout');
+  const req = buildRequest({ headers: { host: 'app.example:3000' } });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(calls.logoutUrl[0].redirectUrl, 'http://app.example:3000/', 'redirect URL should include port');
+  t.end();
+});
+
+test('logout middleware: uses query.redirectUrl when provided', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = logoutMiddleware(keycloak, '/logout');
+  const req = buildRequest({ query: { redirectUrl: 'http://elsewhere.example/done' } });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(calls.logoutUrl[0].redirectUrl, 'http://elsewhere.example/done', 'query.redirectUrl should be used');
+  t.end();
+});
+
+test('logout middleware: redirects to URL produced by keycloak.logoutUrl', t => {
+  const { keycloak } = buildKeycloakStub();
+  const middleware = logoutMiddleware(keycloak, '/logout');
+  const req = buildRequest();
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(res._redirects.length, 1, 'one redirect should be issued');
+  t.equal(res._redirects[0].indexOf('id_token_hint=') > 0, true, 'redirect URL should contain id_token_hint');
+  t.end();
+});

--- a/test/unit/logout-middleware-test.js
+++ b/test/unit/logout-middleware-test.js
@@ -112,6 +112,23 @@ test('logout middleware: does not throw when grant has no id_token', t => {
   t.end();
 });
 
+test('logout middleware: does not throw when kauth has no grant (expired session)', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = logoutMiddleware(keycloak, '/logout');
+  const req = buildRequest();
+  delete req.kauth.grant;
+  const res = buildResponse();
+
+  t.doesNotThrow(() => {
+    middleware(req, res, () => t.fail('next() should not be called'));
+  });
+  t.equal(calls.logoutUrl.length, 1, 'logoutUrl should still be invoked');
+  t.equal(calls.logoutUrl[0].idTokenHint, undefined, 'idTokenHint should be undefined when grant is absent');
+  t.equal(calls.deauthenticated, 0, 'deauthenticated should not be invoked without a grant');
+  t.equal(res._redirects.length, 1, 'request should still be redirected');
+  t.end();
+});
+
 test('logout middleware: builds redirect URL from request.protocol/hostname when no query.redirectUrl', t => {
   const { keycloak, calls } = buildKeycloakStub();
   const middleware = logoutMiddleware(keycloak, '/logout');


### PR DESCRIPTION
## Summary
- Keycloak 26 displays a logout confirmation page unless the logout request includes `id_token_hint` and `client_id`. `Keycloak.prototype.logoutUrl` now accepts an optional `idTokenHint` and appends both query params when present.
- The logout middleware captures `request.kauth.grant.id_token.token` **before** the grant is unstored, then passes it into `logoutUrl` so the user is redirected straight to the post-logout URL.
- Adds unit tests for the new `logoutUrl` behavior and a new `logout-middleware-test.js` covering path bypass, id_token capture ordering, missing id_token, redirect URL derivation (with/without port), `query.redirectUrl` override, and the final redirect.
- Gates the Jenkins `Publish` stage on the `master` branch so feature branches don't trigger publishes.

## Test plan
- [x] `npx tape test/unit/keycloak-object-test.js test/unit/logout-middleware-test.js` — 30/30 pass
- [ ] Manual verification against a Keycloak 26 realm: logging out redirects to the post-logout URL without the confirmation page

🤖 Generated with [Claude Code](https://claude.com/claude-code)