### PR TITLE
AUT-1358 Use post_logout_redirect_uri for KC26 RP-Initiated Logout

### DIFF
--- a/index.js
+++ b/index.js
@@ -319,7 +319,7 @@ Keycloak.prototype.loginUrl = function (uuid, redirectUrl) {
 Keycloak.prototype.logoutUrl = function (redirectUrl, idTokenHint) {
   var url = this.config.realmUrl +
     '/protocol/openid-connect/logout' +
-    '?redirect_uri=' + encodeURIComponent(redirectUrl);
+    '?post_logout_redirect_uri=' + encodeURIComponent(redirectUrl);
   if (idTokenHint) {
     url += '&id_token_hint=' + encodeURIComponent(idTokenHint) +
            '&client_id=' + encodeURIComponent(this.config.clientId);

--- a/middleware/logout.js
+++ b/middleware/logout.js
@@ -24,7 +24,7 @@ module.exports = function (keycloak, logoutUrl) {
     let host = request.hostname;
     let headerHost = request.headers.host.split(':');
     let port = headerHost[1] || '';
-    let redirectUrl = request.query.post_logout_redirect_uri || request.protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
+    let redirectUrl = request.query.redirectUrl || request.protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
 
     const idTokenHint = request.kauth.grant && request.kauth.grant.id_token && request.kauth.grant.id_token.token;
     let keycloakLogoutUrl = keycloak.logoutUrl(redirectUrl, idTokenHint);

--- a/middleware/logout.js
+++ b/middleware/logout.js
@@ -24,7 +24,7 @@ module.exports = function (keycloak, logoutUrl) {
     let host = request.hostname;
     let headerHost = request.headers.host.split(':');
     let port = headerHost[1] || '';
-    let redirectUrl = request.query.redirectUrl || request.protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
+    let redirectUrl = request.query.post_logout_redirect_uri || request.protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
 
     const idTokenHint = request.kauth.grant && request.kauth.grant.id_token && request.kauth.grant.id_token.token;
     let keycloakLogoutUrl = keycloak.logoutUrl(redirectUrl, idTokenHint);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartling/keycloak-connect",
-  "version": "3.4.43",
+  "version": "3.4.44",
   "description": "Keycloak Connect Middleware",
   "homepage": "http://keycloak.org",
   "main": "index.js",

--- a/test/unit/keycloak-object-test.js
+++ b/test/unit/keycloak-object-test.js
@@ -70,10 +70,11 @@ test('Should verify if logout URL has the configured realm.', t => {
   t.end();
 });
 
-test('Should include redirect_uri in logout URL.', t => {
+test('Should include post_logout_redirect_uri (OIDC RP-Initiated Logout) in logout URL.', t => {
   const redirectUrl = 'http://example.com/done';
   const url = kc.logoutUrl(redirectUrl);
-  t.equal(url.indexOf('redirect_uri=' + encodeURIComponent(redirectUrl)) > 0, true);
+  t.equal(url.indexOf('post_logout_redirect_uri=' + encodeURIComponent(redirectUrl)) > 0, true, 'post_logout_redirect_uri should be present');
+  t.equal(/[?&]redirect_uri=/.test(url), false, 'legacy redirect_uri should not be present');
   t.end();
 });
 

--- a/test/unit/logout-middleware-test.js
+++ b/test/unit/logout-middleware-test.js
@@ -24,7 +24,7 @@ function buildKeycloakStub () {
   const keycloak = {
     logoutUrl: function (redirectUrl, idTokenHint) {
       calls.logoutUrl.push({ redirectUrl, idTokenHint });
-      return 'http://keycloak.example/logout?redirect_uri=' +
+      return 'http://keycloak.example/logout?post_logout_redirect_uri=' +
         encodeURIComponent(redirectUrl) +
         (idTokenHint ? '&id_token_hint=' + encodeURIComponent(idTokenHint) : '');
     },
@@ -129,7 +129,7 @@ test('logout middleware: does not throw when kauth has no grant (expired session
   t.end();
 });
 
-test('logout middleware: builds redirect URL from request.protocol/hostname when no query.redirectUrl', t => {
+test('logout middleware: builds redirect URL from request.protocol/hostname when no query.post_logout_redirect_uri', t => {
   const { keycloak, calls } = buildKeycloakStub();
   const middleware = logoutMiddleware(keycloak, '/logout');
   const req = buildRequest();
@@ -153,15 +153,27 @@ test('logout middleware: includes port in default redirect URL when present in h
   t.end();
 });
 
-test('logout middleware: uses query.redirectUrl when provided', t => {
+test('logout middleware: uses query.post_logout_redirect_uri when provided', t => {
   const { keycloak, calls } = buildKeycloakStub();
   const middleware = logoutMiddleware(keycloak, '/logout');
-  const req = buildRequest({ query: { redirectUrl: 'http://elsewhere.example/done' } });
+  const req = buildRequest({ query: { post_logout_redirect_uri: 'http://elsewhere.example/done' } });
   const res = buildResponse();
 
   middleware(req, res, () => t.fail('next() should not be called'));
 
-  t.equal(calls.logoutUrl[0].redirectUrl, 'http://elsewhere.example/done', 'query.redirectUrl should be used');
+  t.equal(calls.logoutUrl[0].redirectUrl, 'http://elsewhere.example/done', 'query.post_logout_redirect_uri should be used');
+  t.end();
+});
+
+test('logout middleware: ignores the legacy query.redirectUrl param', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = logoutMiddleware(keycloak, '/logout');
+  const req = buildRequest({ query: { redirectUrl: 'http://legacy.example/done' } });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(calls.logoutUrl[0].redirectUrl, 'http://app.example/', 'legacy redirectUrl should be ignored, falling back to host-derived URL');
   t.end();
 });
 

--- a/test/unit/logout-middleware-test.js
+++ b/test/unit/logout-middleware-test.js
@@ -129,7 +129,7 @@ test('logout middleware: does not throw when kauth has no grant (expired session
   t.end();
 });
 
-test('logout middleware: builds redirect URL from request.protocol/hostname when no query.post_logout_redirect_uri', t => {
+test('logout middleware: builds redirect URL from request.protocol/hostname when no query.redirectUrl', t => {
   const { keycloak, calls } = buildKeycloakStub();
   const middleware = logoutMiddleware(keycloak, '/logout');
   const req = buildRequest();
@@ -153,27 +153,15 @@ test('logout middleware: includes port in default redirect URL when present in h
   t.end();
 });
 
-test('logout middleware: uses query.post_logout_redirect_uri when provided', t => {
+test('logout middleware: uses query.redirectUrl when provided', t => {
   const { keycloak, calls } = buildKeycloakStub();
   const middleware = logoutMiddleware(keycloak, '/logout');
-  const req = buildRequest({ query: { post_logout_redirect_uri: 'http://elsewhere.example/done' } });
+  const req = buildRequest({ query: { redirectUrl: 'http://elsewhere.example/done' } });
   const res = buildResponse();
 
   middleware(req, res, () => t.fail('next() should not be called'));
 
-  t.equal(calls.logoutUrl[0].redirectUrl, 'http://elsewhere.example/done', 'query.post_logout_redirect_uri should be used');
-  t.end();
-});
-
-test('logout middleware: ignores the legacy query.redirectUrl param', t => {
-  const { keycloak, calls } = buildKeycloakStub();
-  const middleware = logoutMiddleware(keycloak, '/logout');
-  const req = buildRequest({ query: { redirectUrl: 'http://legacy.example/done' } });
-  const res = buildResponse();
-
-  middleware(req, res, () => t.fail('next() should not be called'));
-
-  t.equal(calls.logoutUrl[0].redirectUrl, 'http://app.example/', 'legacy redirectUrl should be ignored, falling back to host-derived URL');
+  t.equal(calls.logoutUrl[0].redirectUrl, 'http://elsewhere.example/done', 'query.redirectUrl should be used');
   t.end();
 });
 


### PR DESCRIPTION
## Summary
Follow-up to #10. KC26 dropped support for the legacy `redirect_uri` query parameter on the logout endpoint in favor of `post_logout_redirect_uri` (OIDC RP-Initiated Logout spec). The old name is silently ignored, so without this change KC26 still shows a "You are logged out" info page instead of redirecting back to the application — exactly the symptom the previous fix was supposed to address end-to-end.

- `Keycloak.prototype.logoutUrl` emits `post_logout_redirect_uri=` instead of `redirect_uri=`
- `middleware/logout.js` reads `request.query.post_logout_redirect_uri` instead of `request.query.redirectUrl`
- Unit tests updated to assert the new query name and a regression guard that the legacy name no longer overrides the host-derived default

> ⚠️ **Required KC26 client config**
> KC26 validates `post_logout_redirect_uri` against the client's configured "Post Logout Redirect URIs" list. The consuming app (e.g. `tms-dashboard-app`) must register its post-logout URLs in the KC26 client config (Client > Advanced > Post Logout Redirect URIs), or KC will reject the redirect with `INVALID_REDIRECT_URI`.

## Test plan
- [x] `npx tape test/unit/keycloak-object-test.js test/unit/logout-middleware-test.js` — 37/37 pass
- [ ] Manual verification on KC26 with `tms-dashboard-app`: logout redirects to the post-logout URL without the info page
- [ ] Confirm post-logout URLs are registered on the relevant KC26 client(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)