### PR TITLE
AUT-1383 Fix logout "Missing parameters: id_token_hint" error after KC26 SSO session expiry

### DIFF
--- a/index.js
+++ b/index.js
@@ -317,12 +317,9 @@ Keycloak.prototype.loginUrl = function (uuid, redirectUrl) {
 };
 
 Keycloak.prototype.logoutUrl = function (redirectUrl, idTokenHint) {
-  var url = this.config.realmUrl +
-    '/protocol/openid-connect/logout' +
-    '?post_logout_redirect_uri=' + encodeURIComponent(redirectUrl);
+  var url = `${this.config.realmUrl}/protocol/openid-connect/logout?post_logout_redirect_uri=${encodeURIComponent(redirectUrl)}&client_id=${encodeURIComponent(this.config.clientId)}`;
   if (idTokenHint) {
-    url += '&id_token_hint=' + encodeURIComponent(idTokenHint) +
-           '&client_id=' + encodeURIComponent(this.config.clientId);
+    url += `&id_token_hint=${encodeURIComponent(idTokenHint)}`;
   }
   return url;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartling/keycloak-connect",
-  "version": "3.4.44",
+  "version": "3.4.45",
   "description": "Keycloak Connect Middleware",
   "homepage": "http://keycloak.org",
   "main": "index.js",

--- a/test/unit/keycloak-object-test.js
+++ b/test/unit/keycloak-object-test.js
@@ -74,18 +74,19 @@ test('Should include post_logout_redirect_uri (OIDC RP-Initiated Logout) in logo
   const redirectUrl = 'http://example.com/done';
   const url = kc.logoutUrl(redirectUrl);
   t.equal(url.indexOf('post_logout_redirect_uri=' + encodeURIComponent(redirectUrl)) > 0, true, 'post_logout_redirect_uri should be present');
+  t.equal(url.indexOf('client_id=' + encodeURIComponent(kc.config.clientId)) > 0, true, 'client_id should be present');
   t.equal(/[?&]redirect_uri=/.test(url), false, 'legacy redirect_uri should not be present');
   t.end();
 });
 
-test('Should not include id_token_hint or client_id when idTokenHint is omitted.', t => {
+test('Should not include id_token_hint when idTokenHint is omitted.', t => {
   const url = kc.logoutUrl('http://example.com/done');
   t.equal(url.indexOf('id_token_hint') === -1, true, 'id_token_hint should not be present');
-  t.equal(url.indexOf('client_id') === -1, true, 'client_id should not be present');
+  t.equal(url.indexOf('client_id=' + encodeURIComponent(kc.config.clientId)) > 0, true, 'client_id should be present');
   t.end();
 });
 
-test('Should append id_token_hint and client_id when idTokenHint is provided.', t => {
+test('Should append id_token_hint when idTokenHint is provided.', t => {
   const idToken = 'fake.id.token';
   const url = kc.logoutUrl('http://example.com/done', idToken);
   t.equal(url.indexOf('id_token_hint=' + encodeURIComponent(idToken)) > 0, true, 'id_token_hint should be appended');
@@ -96,7 +97,7 @@ test('Should append id_token_hint and client_id when idTokenHint is provided.', 
 test('Should treat a falsy idTokenHint the same as no hint.', t => {
   const url = kc.logoutUrl('http://example.com/done', '');
   t.equal(url.indexOf('id_token_hint') === -1, true, 'id_token_hint should not be present for empty string');
-  t.equal(url.indexOf('client_id') === -1, true, 'client_id should not be present for empty string');
+  t.equal(url.indexOf('client_id=' + encodeURIComponent(kc.config.clientId)) > 0, true, 'client_id should be appended');
   t.end();
 });
 


### PR DESCRIPTION
## Summary

Fixes logout failure when the KC26 SSO session has already expired before the user clicks logout.

**Root cause:** `Keycloak.prototype.logoutUrl` only appended `client_id` inside the `if (idTokenHint)` block. When the KC SSO session expires, `getGrant` fails, `request.kauth.grant` is `undefined`, `idTokenHint` is `undefined`, and neither `client_id` nor `id_token_hint` was added to the logout URL. KC26 requires at least one of them when `post_logout_redirect_uri` is present, returning: `Missing parameters: id_token_hint`.

**Fix:** Move `client_id` outside the `if (idTokenHint)` block so it is always appended. KC26 then auto-redirects to `post_logout_redirect_uri` without a confirmation page even when the session is already gone.

## Changes

- **`index.js`** — `client_id` is now always included in the logout URL; `id_token_hint` is still only appended when available
- **`test/unit/keycloak-object-test.js`** — updated assertions to reflect that `client_id` is always present in the logout URL
- **`package.json`** — version bumped to 3.4.45

## Test plan

- [ ] Unit tests in `test/unit/keycloak-object-test.js` pass — all `logoutUrl` assertions updated to expect `client_id` unconditionally
- [ ] Verify on staging: log in, wait for KC SSO session idle timeout + access token TTL to expire, then log out — should redirect cleanly with no "Missing parameters" error page

Closes [AUT-1383](https://smartling.atlassian.net/browse/AUT-1383)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AUT-1383]: https://smartling.atlassian.net/browse/AUT-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ