### PR TITLE
AUT-1462 Fix infinite redirect loop from session-cap re-login (#2)

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ var Logout = require('./middleware/logout');
 var PostAuth = require('./middleware/post-auth');
 var GrantAttacher = require('./middleware/grant-attacher');
 var Protect = require('./middleware/protect');
+const { SessionExpiredError } = require('./middleware/auth-utils/errors');
 
 /**
  * Instantiate a Keycloak.
@@ -259,10 +260,12 @@ Keycloak.prototype.getGrant = function (request, response) {
       return grant;
     })
     .catch((e) => {
-      // Pass Error instances through unchanged so structured rejections (e.g. session-cap guard)
-      // reach the caller with their original message rather than being re-wrapped.
+      if (e instanceof SessionExpiredError && e.grant && self.stores.length >= 2) {
+        self.stores[1].wrap(e.grant);
+        return Promise.reject(e);
+      }
       if (e instanceof Error) return Promise.reject(e);
-      return Promise.reject(new Error('Could not store grant code error. ' + e));
+      return Promise.reject(new Error('Failed to process grant: ' + e));
     });
   }
 

--- a/middleware/auth-utils/errors.js
+++ b/middleware/auth-utils/errors.js
@@ -1,0 +1,12 @@
+'use strict';
+
+class SessionExpiredError extends Error {
+  constructor (grant) {
+    super('Session near maximum lifespan: re-login required');
+    this.name = 'SessionExpiredError';
+    this.grant = grant;
+    this.idTokenHint = grant && grant.id_token && grant.id_token.token;
+  }
+}
+
+module.exports = { SessionExpiredError };

--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -23,6 +23,7 @@ const querystring = require('querystring');
 const Grant = require('./grant');
 const Token = require('./token');
 var Rotation = require('./rotation');
+const { SessionExpiredError } = require('./errors');
 
 /**
  * Construct a grant manager.
@@ -163,7 +164,7 @@ GrantManager.prototype.ensureFreshness = function ensureFreshness (grant, callba
     // login instead.
     const issuedLifetime = grant.access_token.content.exp - grant.access_token.content.iat;
     if (issuedLifetime < this.tokenMinTtl) {
-      return nodeify(Promise.reject(new Error('Session near maximum lifespan: re-login required')), callback);
+      return nodeify(Promise.reject(new SessionExpiredError(grant)), callback);
     }
   }
 

--- a/middleware/grant-attacher.js
+++ b/middleware/grant-attacher.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const { SessionExpiredError } = require('./auth-utils/errors');
-const { performLogout } = require('./logout');
+const { logoutAndRedirect } = require('./logout');
 
 module.exports = function (keycloak) {
   return function grantAttacher (request, response, next) {
@@ -32,7 +32,7 @@ module.exports = function (keycloak) {
           if (err.grant && err.grant.unstore) {
             request.kauth.grant = err.grant;
           }
-          return performLogout(keycloak, request, response);
+          return logoutAndRedirect(keycloak, request, response);
         }
 
         // err can be undefined

--- a/middleware/grant-attacher.js
+++ b/middleware/grant-attacher.js
@@ -15,6 +15,9 @@
  */
 'use strict';
 
+const { SessionExpiredError } = require('./auth-utils/errors');
+const { performLogout } = require('./logout');
+
 module.exports = function (keycloak) {
   return function grantAttacher (request, response, next) {
     keycloak.getGrant(request, response)
@@ -22,6 +25,16 @@ module.exports = function (keycloak) {
         request.kauth.grant = grant;
       })
         .then(next).catch(err => {
+        if (err instanceof SessionExpiredError) {
+          // Session has reached maximum lifespan. A simple re-login redirect would loop because
+          // Keycloak's SSO session is still alive. Perform a full RP-initiated logout first to
+          // clear the Keycloak session, then the subsequent login redirect will work correctly.
+          if (err.grant && err.grant.unstore) {
+            request.kauth.grant = err.grant;
+          }
+          return performLogout(keycloak, request, response);
+        }
+
         // err can be undefined
           if (err) {
             console.error('Failed to get grant', err);

--- a/middleware/logout.js
+++ b/middleware/logout.js
@@ -15,26 +15,31 @@
  */
 'use strict';
 
+function performLogout (keycloak, request, response) {
+  let host = request.hostname;
+  let headerHost = request.headers.host.split(':');
+  let port = headerHost[1] || '';
+  let redirectUrl = request.query.redirectUrl || request.protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
+
+  const idTokenHint = request.kauth.grant && request.kauth.grant.id_token && request.kauth.grant.id_token.token;
+  let keycloakLogoutUrl = keycloak.logoutUrl(redirectUrl, idTokenHint);
+
+  if (request.kauth.grant) {
+    keycloak.deauthenticated(request);
+    request.kauth.grant.unstore(request, response);
+    delete request.kauth.grant;
+  }
+
+  response.redirect(keycloakLogoutUrl);
+}
+
 module.exports = function (keycloak, logoutUrl) {
   return function logout (request, response, next) {
     if (request.path !== logoutUrl) {
       return next();
     }
-
-    let host = request.hostname;
-    let headerHost = request.headers.host.split(':');
-    let port = headerHost[1] || '';
-    let redirectUrl = request.query.redirectUrl || request.protocol + '://' + host + (port === '' ? '' : ':' + port) + '/';
-
-    const idTokenHint = request.kauth.grant && request.kauth.grant.id_token && request.kauth.grant.id_token.token;
-    let keycloakLogoutUrl = keycloak.logoutUrl(redirectUrl, idTokenHint);
-
-    if (request.kauth.grant) {
-      keycloak.deauthenticated(request);
-      request.kauth.grant.unstore(request, response);
-      delete request.kauth.grant;
-    }
-
-    response.redirect(keycloakLogoutUrl);
+    performLogout(keycloak, request, response);
   };
 };
+
+module.exports.performLogout = performLogout;

--- a/middleware/logout.js
+++ b/middleware/logout.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-function performLogout (keycloak, request, response) {
+function logoutAndRedirect (keycloak, request, response) {
   let host = request.hostname;
   let headerHost = request.headers.host.split(':');
   let port = headerHost[1] || '';
@@ -38,8 +38,8 @@ module.exports = function (keycloak, logoutUrl) {
     if (request.path !== logoutUrl) {
       return next();
     }
-    performLogout(keycloak, request, response);
+    logoutAndRedirect(keycloak, request, response);
   };
 };
 
-module.exports.performLogout = performLogout;
+module.exports.logoutAndRedirect = logoutAndRedirect;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartling/keycloak-connect",
-  "version": "3.4.46",
+  "version": "3.4.47",
   "description": "Keycloak Connect Middleware",
   "homepage": "http://keycloak.org",
   "main": "index.js",

--- a/test/unit/grant-attacher-unit-test.js
+++ b/test/unit/grant-attacher-unit-test.js
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2016 Red Hat Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+'use strict';
+
+const test = require('tape');
+const grantAttacherMiddleware = require('../../middleware/grant-attacher');
+const { SessionExpiredError } = require('../../middleware/auth-utils/errors');
+
+function buildRequest () {
+  return {
+    hostname: 'app.example',
+    protocol: 'https',
+    headers: { host: 'app.example' },
+    query: {},
+    kauth: {}
+  };
+}
+
+function buildResponse () {
+  const redirects = [];
+  return {
+    redirect: (url) => { redirects.push(url); },
+    _redirects: redirects
+  };
+}
+
+function buildKeycloakStub ({ getGrantResult } = {}) {
+  const deauthCalls = [];
+  const keycloak = {
+    getGrant: () => getGrantResult,
+    logoutUrl: (redirectUrl, idTokenHint) => {
+      return 'https://keycloak.example/logout?redirect=' + encodeURIComponent(redirectUrl) +
+        (idTokenHint ? '&id_token_hint=' + encodeURIComponent(idTokenHint) : '');
+    },
+    deauthenticated: (req) => { deauthCalls.push(req); }
+  };
+  return { keycloak, deauthCalls };
+}
+
+// Builds a SessionExpiredError whose .grant has already been wrapped by getGrant
+// (i.e. has a working unstore method), matching what index.js produces.
+function buildSessionExpiredError ({ idTokenHint } = {}) {
+  const unstoreCalls = [];
+  const grant = {
+    id_token: idTokenHint ? { token: idTokenHint } : undefined,
+    unstore: (req, res) => { unstoreCalls.push({ req, res }); }
+  };
+  const err = new SessionExpiredError(grant);
+  err._unstoreCalls = unstoreCalls;
+  return err;
+}
+
+test('grant-attacher: attaches grant and calls next() on success', t => {
+  const fakeGrant = { access_token: {} };
+  const { keycloak } = buildKeycloakStub({ getGrantResult: Promise.resolve(fakeGrant) });
+  const middleware = grantAttacherMiddleware(keycloak);
+  const req = buildRequest();
+  const res = buildResponse();
+
+  middleware(req, res, () => {
+    t.equal(req.kauth.grant, fakeGrant, 'grant is set on request.kauth');
+    t.equal(res._redirects.length, 0, 'no redirect should occur');
+    t.end();
+  });
+});
+
+test('grant-attacher: calls next() and logs on generic error', t => {
+  const { keycloak } = buildKeycloakStub({ getGrantResult: Promise.reject(new Error('token invalid')) });
+  const middleware = grantAttacherMiddleware(keycloak);
+  const req = buildRequest();
+  const res = buildResponse();
+
+  middleware(req, res, () => {
+    t.equal(req.kauth.grant, undefined, 'grant is not set');
+    t.equal(res._redirects.length, 0, 'no redirect on generic error');
+    t.end();
+  });
+});
+
+test('grant-attacher: calls next() silently when getGrant rejects with no error', t => {
+  const { keycloak } = buildKeycloakStub({ getGrantResult: Promise.reject() });
+  const middleware = grantAttacherMiddleware(keycloak);
+  const req = buildRequest();
+  const res = buildResponse();
+
+  middleware(req, res, () => {
+    t.equal(res._redirects.length, 0, 'no redirect');
+    t.end();
+  });
+});
+
+test('grant-attacher: SessionExpiredError triggers RP-initiated logout redirect', t => {
+  const err = buildSessionExpiredError({ idTokenHint: 'id.token.hint' });
+  const { keycloak, deauthCalls } = buildKeycloakStub({ getGrantResult: Promise.reject(err) });
+  const middleware = grantAttacherMiddleware(keycloak);
+  const req = buildRequest();
+  const res = buildResponse();
+
+  middleware(req, res, () => { t.fail('next() should not be called'); });
+
+  setTimeout(() => {
+    t.equal(res._redirects.length, 1, 'one redirect issued');
+    t.ok(res._redirects[0].includes('id_token_hint='), 'redirect URL includes id_token_hint');
+    t.equal(err._unstoreCalls.length, 1, 'grant.unstore was called to clear the session');
+    t.equal(deauthCalls.length, 1, 'keycloak.deauthenticated was called');
+    t.end();
+  }, 10);
+});
+
+test('grant-attacher: SessionExpiredError without idTokenHint still redirects to logout', t => {
+  const err = buildSessionExpiredError({ idTokenHint: undefined });
+  const { keycloak, deauthCalls } = buildKeycloakStub({ getGrantResult: Promise.reject(err) });
+  const middleware = grantAttacherMiddleware(keycloak);
+  const req = buildRequest();
+  const res = buildResponse();
+
+  middleware(req, res, () => { t.fail('next() should not be called'); });
+
+  setTimeout(() => {
+    t.equal(res._redirects.length, 1, 'one redirect issued');
+    t.notOk(res._redirects[0].includes('id_token_hint='), 'no id_token_hint when hint is absent');
+    t.equal(err._unstoreCalls.length, 1, 'grant.unstore was called');
+    t.equal(deauthCalls.length, 1, 'keycloak.deauthenticated was called');
+    t.end();
+  }, 10);
+});
+
+test('grant-attacher: SessionExpiredError with unwrapped grant skips unstore but still redirects', t => {
+  // Simulates the bearer-only edge case: getGrant skips wrap when stores.length < 2,
+  // so err.grant exists but has no unstore method.
+  const err = new SessionExpiredError({ id_token: undefined }); // grant without unstore — not wrapped
+  const { keycloak, deauthCalls } = buildKeycloakStub({ getGrantResult: Promise.reject(err) });
+  const middleware = grantAttacherMiddleware(keycloak);
+  const req = buildRequest();
+  const res = buildResponse();
+
+  middleware(req, res, () => { t.fail('next() should not be called'); });
+
+  setTimeout(() => {
+    t.equal(res._redirects.length, 1, 'redirect issued even without wrapped grant');
+    t.equal(deauthCalls.length, 0, 'deauthenticated not called when grant has no unstore');
+    t.end();
+  }, 10);
+});
+
+test('grant-attacher: SessionExpiredError redirect URL uses request protocol and hostname', t => {
+  const err = buildSessionExpiredError({ idTokenHint: undefined });
+  const { keycloak } = buildKeycloakStub({ getGrantResult: Promise.reject(err) });
+  const middleware = grantAttacherMiddleware(keycloak);
+  const req = buildRequest();
+  req.protocol = 'https';
+  req.hostname = 'myapp.example';
+  req.headers = { host: 'myapp.example:3000' };
+  const res = buildResponse();
+
+  middleware(req, res, () => { t.fail('next() should not be called'); });
+
+  setTimeout(() => {
+    t.ok(res._redirects[0].includes(encodeURIComponent('https://myapp.example:3000/')),
+      'redirect URL includes correct origin with port');
+    t.end();
+  }, 10);
+});

--- a/test/unit/grant-manager-unit-test.js
+++ b/test/unit/grant-manager-unit-test.js
@@ -2,6 +2,7 @@
 
 const test = require('tape');
 const GrantManager = require('../../middleware/auth-utils/grant-manager');
+const { SessionExpiredError } = require('../../middleware/auth-utils/errors');
 
 const nock = require('nock');
 
@@ -73,6 +74,7 @@ test('session-capped token (exp-iat=88, min-ttl=90) triggers re-login rejection'
   mgr.ensureFreshness(grant)
     .then(() => { t.fail('should have rejected'); t.end(); })
     .catch(err => {
+      t.ok(err instanceof SessionExpiredError, 'error is a SessionExpiredError');
       t.equal(err.message, 'Session near maximum lifespan: re-login required');
       t.end();
     });
@@ -86,6 +88,7 @@ test('session-capped token one second inside min-ttl threshold triggers re-login
   mgr.ensureFreshness(grant)
     .then(() => { t.fail('should have rejected'); t.end(); })
     .catch(err => {
+      t.ok(err instanceof SessionExpiredError, 'error is a SessionExpiredError');
       t.equal(err.message, 'Session near maximum lifespan: re-login required');
       t.end();
     });
@@ -99,6 +102,7 @@ test('session-capped token with 1s issued lifetime triggers re-login rejection',
   mgr.ensureFreshness(grant)
     .then(() => { t.fail('should have rejected'); t.end(); })
     .catch(err => {
+      t.ok(err instanceof SessionExpiredError, 'error is a SessionExpiredError');
       t.equal(err.message, 'Session near maximum lifespan: re-login required');
       t.end();
     });
@@ -110,9 +114,39 @@ test('session-capped token via callback style delivers error to callback', t => 
   const grant = withRtExpired(makeGrant({ atExp: n + 86, atIat: n - 2, rtJti: 'jti-4' }), false);
   mgr.ensureFreshness(grant, (err) => {
     t.ok(err, 'error passed to callback');
+    t.ok(err instanceof SessionExpiredError, 'error is a SessionExpiredError');
     t.equal(err.message, 'Session near maximum lifespan: re-login required');
     t.end();
   });
+});
+
+test('session-capped token carries grant and idTokenHint from grant id_token', t => {
+  const mgr = makeManager(90);
+  const n = nowSec();
+  const grant = withRtExpired(makeGrant({ atExp: n + 86, atIat: n - 2, rtJti: 'jti-hint' }), false);
+  grant.id_token = { token: 'id.token.value' };
+  mgr.ensureFreshness(grant)
+    .then(() => { t.fail('should have rejected'); t.end(); })
+    .catch(err => {
+      t.ok(err instanceof SessionExpiredError, 'error is a SessionExpiredError');
+      t.equal(err.grant, grant, 'error carries the grant object');
+      t.equal(err.idTokenHint, 'id.token.value', 'idTokenHint is derived from grant.id_token.token');
+      t.end();
+    });
+});
+
+test('session-capped token has undefined idTokenHint when grant has no id_token', t => {
+  const mgr = makeManager(90);
+  const n = nowSec();
+  const grant = withRtExpired(makeGrant({ atExp: n + 86, atIat: n - 2, rtJti: 'jti-nohint' }), false);
+  mgr.ensureFreshness(grant)
+    .then(() => { t.fail('should have rejected'); t.end(); })
+    .catch(err => {
+      t.ok(err instanceof SessionExpiredError, 'error is a SessionExpiredError');
+      t.equal(err.grant, grant, 'error carries the grant object');
+      t.equal(err.idTokenHint, undefined, 'idTokenHint is undefined when no id_token present');
+      t.end();
+    });
 });
 
 test('token with issued lifetime equal to min-ttl boundary is not treated as capped', t => {
@@ -421,7 +455,7 @@ test('session-cap guard fires inside createGrant when KC returns a capped token,
 
   Promise.all([p1.catch(e => e), p2.catch(e => e), p3.catch(e => e)])
     .then(([e1, e2, e3]) => {
-      t.ok(e1 instanceof Error, 'all callers rejected with Error');
+      t.ok(e1 instanceof SessionExpiredError, 'all callers rejected with SessionExpiredError');
       t.equal(e1.message, 'Session near maximum lifespan: re-login required',
         'session-cap error message propagates through refreshPromise to all callers');
       t.equal(e1, e2, 'p2 shares same rejection object as p1 (dedup)');


### PR DESCRIPTION
## Context

Follow-up to #15 (AUT-1462 first fix). The session-cap detection landed correctly, but its error handling caused a new problem: infinite redirects between the app and Keycloak.

## Root cause of the regression

When `ensureFreshness` detected a session-capped token it threw a generic `Error`. `grant-attacher.js` caught it and called `next()` with no grant attached. `protect.js` then redirected to Keycloak login — but the Keycloak SSO session was still alive, so Keycloak silently re-authenticated and bounced the user straight back. Repeat indefinitely.

## Fix

- **`middleware/auth-utils/errors.js`** (new) — `SessionExpiredError` subclass that carries the grant object and derives `idTokenHint` from it
- **`middleware/auth-utils/grant-manager.js`** — throws `SessionExpiredError(grant)` instead of a generic `Error`
- **`index.js`** (`getGrant`) — catches `SessionExpiredError` and calls `stores[1].wrap(e.grant)` so the grant has a working `unstore` before the error propagates
- **`middleware/logout.js`** — core redirect logic extracted into a named `performLogout` helper for reuse
- **`middleware/grant-attacher.js`** — catches `SessionExpiredError` specifically, sets `request.kauth.grant = err.grant`, and calls `performLogout` to clear the local session and perform RP-initiated logout before any login redirect; Keycloak's SSO session is gone by the time the user is sent back

## Test plan

- [ ] All existing unit tests pass: `node test/unit/grant-manager-unit-test.js` (41 tests)
- [ ] New `grant-attacher` unit tests pass: `node test/unit/grant-attacher-unit-test.js` (16 tests)
- [ ] Existing logout middleware tests pass: `node test/unit/logout-middleware-test.js` (20 tests)
- [ ] Manual: user approaching KC26 12h SSO session max is redirected to Keycloak logout, then to login — no infinite redirect loop

Closes AUT-1462

🤖 Generated with [Claude Code](https://claude.com/claude-code)