### PR TITLE
AUT-1462 Only logout-redirect on navigational requests to prevent token storm (#3)

### DIFF
--- a/middleware/grant-attacher.js
+++ b/middleware/grant-attacher.js
@@ -29,13 +29,19 @@ module.exports = function (keycloak) {
           // Session has reached maximum lifespan. A simple re-login redirect would loop because
           // Keycloak's SSO session is still alive. Perform a full RP-initiated logout first to
           // clear the Keycloak session, then the subsequent login redirect will work correctly.
-          const isNavigational = !request.xhr && !!request.accepts('text/html');
+          // Only redirect browsers (navigational requests) to the logout page.
+          // XHR / fetch / API callers should not receive a redirect response.
+          const isNavigational = !request.xhr &&
+            typeof request.accepts === 'function' &&
+            !!request.accepts('text/html');
           if (isNavigational) {
             if (err.grant && err.grant.unstore) {
               request.kauth.grant = err.grant;
             }
             return logoutAndRedirect(keycloak, request, response);
           }
+          next();
+          return;
         }
 
         // err can be undefined

--- a/middleware/grant-attacher.js
+++ b/middleware/grant-attacher.js
@@ -29,10 +29,13 @@ module.exports = function (keycloak) {
           // Session has reached maximum lifespan. A simple re-login redirect would loop because
           // Keycloak's SSO session is still alive. Perform a full RP-initiated logout first to
           // clear the Keycloak session, then the subsequent login redirect will work correctly.
-          if (err.grant && err.grant.unstore) {
-            request.kauth.grant = err.grant;
+          const isNavigational = !request.xhr && !!request.accepts('text/html');
+          if (isNavigational) {
+            if (err.grant && err.grant.unstore) {
+              request.kauth.grant = err.grant;
+            }
+            return logoutAndRedirect(keycloak, request, response);
           }
-          return logoutAndRedirect(keycloak, request, response);
         }
 
         // err can be undefined

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartling/keycloak-connect",
-  "version": "3.4.47",
+  "version": "3.4.48",
   "description": "Keycloak Connect Middleware",
   "homepage": "http://keycloak.org",
   "main": "index.js",

--- a/test/unit/grant-attacher-unit-test.js
+++ b/test/unit/grant-attacher-unit-test.js
@@ -19,13 +19,15 @@ const test = require('tape');
 const grantAttacherMiddleware = require('../../middleware/grant-attacher');
 const { SessionExpiredError } = require('../../middleware/auth-utils/errors');
 
-function buildRequest () {
+function buildRequest ({ xhr = false, acceptsHtml = true } = {}) {
   return {
     hostname: 'app.example',
     protocol: 'https',
     headers: { host: 'app.example' },
     query: {},
-    kauth: {}
+    kauth: {},
+    xhr,
+    accepts: (type) => acceptsHtml && type === 'text/html'
   };
 }
 
@@ -173,4 +175,30 @@ test('grant-attacher: SessionExpiredError redirect URL uses request protocol and
       'redirect URL includes correct origin with port');
     t.end();
   }, 10);
+});
+
+test('grant-attacher: SessionExpiredError on XHR request calls next() without redirecting', t => {
+  const err = buildSessionExpiredError({ idTokenHint: 'id.token.hint' });
+  const { keycloak } = buildKeycloakStub({ getGrantResult: Promise.reject(err) });
+  const middleware = grantAttacherMiddleware(keycloak);
+  const req = buildRequest({ xhr: true });
+  const res = buildResponse();
+
+  middleware(req, res, () => {
+    t.equal(res._redirects.length, 0, 'no redirect for XHR request');
+    t.end();
+  });
+});
+
+test('grant-attacher: SessionExpiredError on API request (no text/html) calls next() without redirecting', t => {
+  const err = buildSessionExpiredError({ idTokenHint: 'id.token.hint' });
+  const { keycloak } = buildKeycloakStub({ getGrantResult: Promise.reject(err) });
+  const middleware = grantAttacherMiddleware(keycloak);
+  const req = buildRequest({ acceptsHtml: false });
+  const res = buildResponse();
+
+  middleware(req, res, () => {
+    t.equal(res._redirects.length, 0, 'no redirect for non-HTML request');
+    t.end();
+  });
 });


### PR DESCRIPTION
## Summary

- **Root cause addressed:** When the KC26 session-cap error fired, `grant-attacher.js` was calling `logoutAndRedirect` for every request — including XHR/API calls from ti-next. Each background request triggered an RP-initiated logout+redirect instead of returning an error, which caused the ~1200 req/s refresh token storm near the 12h SSO session max.
- **Fix:** Gate the logout-and-redirect on navigational requests only (`!request.xhr && request.accepts('text/html')`). Non-navigational requests (API/XHR) fall through to normal error handling instead of being redirected.
- **Version:** bumped to `3.4.48`.

## Test plan

- [ ] Verify browser page navigations near session end still trigger the RP-initiated logout+redirect flow correctly
- [ ] Verify XHR/API requests near session end do NOT trigger a redirect (return an error response instead)
- [ ] Confirm no infinite redirect loop regression (previous fix from #17 still intact)
- [ ] Deploy to staging and confirm refresh token storm does not recur near 12h SSO session expiry

Closes [AUT-1462](https://smartling.atlassian.net/browse/AUT-1462)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AUT-1462]: https://smartling.atlassian.net/browse/AUT-1462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ