### PR TITLE
Aut 1461 encode redirect uri brackets

### DIFF
--- a/middleware/post-auth.js
+++ b/middleware/post-auth.js
@@ -73,6 +73,8 @@ module.exports = function (keycloak) {
         delete urlParts.query.code;
         delete urlParts.query.auth_callback;
         delete urlParts.query.state;
+        delete urlParts.query.session_state;
+        delete urlParts.query.iss;
 
         let cleanUrl = URL.format(urlParts);
 

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -17,14 +17,31 @@
 
 const UUID = require('./../uuid');
 
+// Characters browsers commonly leave unencoded in a query string (per the WHATWG URL
+// spec) but that Keycloak's server-side URI builder percent-encodes when it reconstructs
+// the redirect_uri to build the post-login Location header. If we send them unencoded on
+// the initial /auth request, Keycloak's saved copy no longer matches the encoded form it
+// hands back later, and the code-to-token exchange fails with invalid_redirect_uri. Encode
+// them here so both copies are identical from the start. See AUT-1461.
+const KEYCLOAK_QUERY_UNSAFE_CHARS = /[[\]{}]/g;
+const KEYCLOAK_QUERY_UNSAFE_CHAR_ENCODINGS = { '[': '%5B', ']': '%5D', '{': '%7B', '}': '%7D' };
+
+function encodeUnsafeQueryChars (queryString) {
+  return queryString.replace(KEYCLOAK_QUERY_UNSAFE_CHARS, (char) => KEYCLOAK_QUERY_UNSAFE_CHAR_ENCODINGS[char]);
+}
+
 function forceLogin (keycloak, request, response) {
   let host = request.hostname;
   let headerHost = request.headers.host.split(':');
   let port = headerHost[1] || '';
   let protocol = request.protocol;
-  let hasQuery = ~(request.originalUrl || request.url).indexOf('?');
+  let originalUrl = request.originalUrl || request.url;
+  let queryIndex = originalUrl.indexOf('?');
+  let pathname = queryIndex === -1 ? originalUrl : originalUrl.slice(0, queryIndex);
+  let queryString = queryIndex === -1 ? '' : encodeUnsafeQueryChars(originalUrl.slice(queryIndex + 1));
+  let hasQuery = queryIndex !== -1;
 
-  let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + (request.originalUrl || request.url) + (hasQuery ? '&' : '?') + 'auth_callback=1';
+  let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + pathname + (hasQuery ? '?' + queryString + '&' : '?') + 'auth_callback=1';
 
   if (request.session) {
     request.session.auth_redirect_uri = redirectUrl;

--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -41,7 +41,9 @@ function forceLogin (keycloak, request, response) {
   let queryString = queryIndex === -1 ? '' : encodeUnsafeQueryChars(originalUrl.slice(queryIndex + 1));
   let hasQuery = queryIndex !== -1;
 
-  let redirectUrl = protocol + '://' + host + (port === '' ? '' : ':' + port) + pathname + (hasQuery ? '?' + queryString + '&' : '?') + 'auth_callback=1';
+  let portPart = port === '' ? '' : `:${port}`;
+  let queryPrefix = hasQuery ? `${queryString}&` : '';
+  let redirectUrl = `${protocol}://${host}${portPart}${pathname}?${queryPrefix}auth_callback=1`;
 
   if (request.session) {
     request.session.auth_redirect_uri = redirectUrl;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartling/keycloak-connect",
-  "version": "3.4.50",
+  "version": "3.4.52",
   "description": "Keycloak Connect Middleware",
   "homepage": "http://keycloak.org",
   "main": "index.js",

--- a/test/unit/post-auth-middleware-test.js
+++ b/test/unit/post-auth-middleware-test.js
@@ -133,6 +133,36 @@ test('post-auth: strips code, state, session_state and iss from the reconstructe
   t.end();
 });
 
+test('post-auth: strips session_state and iss, not just code/state/auth_callback, from the browser-facing redirect URL', async t => {
+  const { keycloak } = buildKeycloakStub();
+  const middleware = postAuthMiddleware(keycloak);
+  const req = buildCallbackRequest({
+    path: '/app/account-jobs/',
+    query: {
+      filter: 'CURRENT_WORK',
+      auth_callback: '1',
+      state: 's1',
+      code: 'c1',
+      session_state: 'ss1',
+      iss: 'https://kc.example'
+    }
+  });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  // getGrantFromCode resolves asynchronously; flush microtasks before asserting the redirect.
+  await new Promise(resolve => setImmediate(resolve));
+
+  t.equal(res._redirects.length, 1, 'one redirect issued');
+  t.equal(
+    res._redirects[0],
+    '/app/account-jobs/?filter=CURRENT_WORK',
+    'session_state and iss are stripped from the URL shown to the browser, like code/state/auth_callback'
+  );
+  t.end();
+});
+
 test('post-auth: includes port from the host header in the reconstructed redirect_uri', t => {
   const { keycloak, calls } = buildKeycloakStub();
   const middleware = postAuthMiddleware(keycloak);

--- a/test/unit/protect-middleware-test.js
+++ b/test/unit/protect-middleware-test.js
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2016 Red Hat Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+'use strict';
+
+const test = require('tape');
+const protectMiddleware = require('../../middleware/protect');
+
+function buildKeycloakStub () {
+  const calls = { loginUrl: [] };
+  const keycloak = {
+    redirectToLogin: function () {
+      return true;
+    },
+    loginUrl: function (uuid, redirectUrl) {
+      calls.loginUrl.push({ uuid, redirectUrl });
+      return 'https://kc.example/auth?redirect_uri=' + encodeURIComponent(redirectUrl);
+    }
+  };
+  return { keycloak, calls };
+}
+
+function buildRequest (overrides) {
+  const req = {
+    hostname: 'app.example',
+    protocol: 'https',
+    headers: { host: 'app.example' },
+    originalUrl: '/app/dashboard',
+    session: {}
+  };
+  Object.assign(req, overrides || {});
+  return req;
+}
+
+function buildResponse () {
+  const redirects = [];
+  return {
+    redirect: function (url) {
+      redirects.push(url);
+    },
+    _redirects: redirects
+  };
+}
+
+test('protect: percent-encodes [ and ] in the redirect_uri query string', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = protectMiddleware(keycloak);
+  const req = buildRequest({
+    originalUrl: '/app/account-jobs/?filter=CURRENT_WORK&accountUids[]=c662b7a3&workflowStepTypes[]=TRANSLATION'
+  });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(
+    calls.loginUrl[0].redirectUrl,
+    'https://app.example/app/account-jobs/?filter=CURRENT_WORK&accountUids%5B%5D=c662b7a3&workflowStepTypes%5B%5D=TRANSLATION&auth_callback=1',
+    'brackets in query params are percent-encoded before being sent to Keycloak'
+  );
+  t.end();
+});
+
+test('protect: percent-encodes { and } in the redirect_uri query string', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = protectMiddleware(keycloak);
+  const req = buildRequest({
+    originalUrl: '/app/dashboard?token={abc}'
+  });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(
+    calls.loginUrl[0].redirectUrl,
+    'https://app.example/app/dashboard?token=%7Babc%7D&auth_callback=1',
+    'braces in query params are percent-encoded before being sent to Keycloak'
+  );
+  t.end();
+});
+
+test('protect: leaves already-percent-encoded sequences untouched', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = protectMiddleware(keycloak);
+  const req = buildRequest({
+    originalUrl: '/app/dashboard?redirect=%2Fhome%2Fpage'
+  });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(
+    calls.loginUrl[0].redirectUrl,
+    'https://app.example/app/dashboard?redirect=%2Fhome%2Fpage&auth_callback=1',
+    'existing percent-encoded sequences are not re-encoded'
+  );
+  t.end();
+});
+
+test('protect: does not alter the pathname', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = protectMiddleware(keycloak);
+  const req = buildRequest({
+    originalUrl: '/app/dashboard'
+  });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(
+    calls.loginUrl[0].redirectUrl,
+    'https://app.example/app/dashboard?auth_callback=1',
+    'no query string means no encoding changes and auth_callback is appended with ?'
+  );
+  t.end();
+});


### PR DESCRIPTION
The original AUT-1461 fix (reconstructing `redirect_uri` from the callback URL instead of a
shared session key) solved the multi-tab race, but two more distinct causes of
`invalid_redirect_uri` remained, both introduced/exposed by that same change. This PR fixes
both.

## Problem 1: Reserved query characters get encoded differently by Keycloak on the way out than on the way in

### Symptom

```
2026-07-02 09:25:43,212 +0000 [WARN] [org.keycloak.events] (executor-thread-193) rid= traceId=17b9f0b944ade7b1c69a754d08b9d8f5 type="CODE_TO_TOKEN_ERROR", realmId="1f758f7d-aad6-4f6e-942b-7b112dc31d11", realmName="Smartling", clientId="tms-dashboard-app", userId="c9267f1c-d5ae-4f17-ab55-77bdb776e8f2", sessionId="KnvMk7GJADpgSDPBBV34KIgD", ipAddress="52.70.162.138", error="invalid_redirect_uri", reason="Parameter 'redirect_uri' did not match originally saved redirect URI used in initial OIDC request. Saved redirectUri: https://dashboard.smartling.com/app/account-jobs/?filter=AVAILABLE_TO_ACCEPT&accountUids[]=c662b7a3&workflowStepTypes[]=TRANSLATION&workflowStepTypes[]=POST_TRANSLATION__POST_MACHINE_REVISION&auth_callback=1, redirectUri parameter: https://dashboard.smartling.com/app/account-jobs/?filter=AVAILABLE_TO_ACCEPT&accountUids%5B%5D=c662b7a3&workflowStepTypes%5B%5D=TRANSLATION&workflowStepTypes%5B%5D=POST_TRANSLATION__POST_MACHINE_REVISION&auth_callback=1", grant_type="authorization_code", code_id="KnvMk7GJADpgSDPBBV34KIgD", client_auth_method="client-secret"
```

The only difference between the two strings is that `[` and `]` are literal in the "Saved
redirectUri" but percent-encoded (`%5B`/`%5D`) in the "redirectUri parameter" our adapter
sent back during the code-to-token exchange.

### Root cause

Our adapter never decodes or re-encodes the callback URL when reconstructing `redirect_uri`
(`middleware/post-auth.js`'s `reconstructRedirectUri`) — it takes the raw bytes of
`request.originalUrl` and only strips a fixed set of Keycloak-appended query keys
(`code`, `state`, `session_state`, `iss`). So whatever encoding is present in the actual
browser request is exactly what we send back.

The divergence is introduced by Keycloak itself, between the moment it *saves* the
`redirect_uri` from the initial `/auth` request and the moment it *reconstructs* it into the
`Location` header for the post-login redirect:

- On `/auth`, Keycloak stores the `redirect_uri` value verbatim, with no further encoding
  (`RedirectUtils.verifyRedirectUri`, persisted into `OAuth2Code.redirectUriParam`).
- When building the success redirect, `OIDCLoginProtocol.authenticated()` calls
  `OIDCRedirectUriBuilder.fromUri(redirect, ...)`, which parses the stored URI through
  `KeycloakUriBuilder.fromUri()`. That parse step runs the *existing* query string through
  `Encode.encodeQueryString`, whose character allowlist (unreserved chars plus
  `!$&'()*+,;=:@?/`) does **not** include `[`, `]`, `{`, or `}`. Those characters get
  percent-encoded at that point, before `code`/`state`/`session_state`/`iss` are even
  appended.
- Browsers commonly leave `[`, `]`, `{`, `}` unencoded in query strings (SPAs frequently use
  `key[]=value` array-style query params), so a client's original page URL — and therefore
  the `redirect_uri` it sends on the initial `/auth` request — often contains them literally.

The result: Keycloak's saved copy has literal brackets, but the `Location` header (and thus
the browser's follow-up request, and thus our reconstructed `redirect_uri`) has them
percent-encoded. Keycloak's own literal-string `.equals()` comparison
(`AuthorizationCodeGrantType`) then fails.

### Fix

`middleware/protect.js`'s `forceLogin` — the only place that builds the initial
`redirect_uri` sent to Keycloak — now percent-encodes `[`, `]`, `{`, `}` in the query string
before it's ever sent to Keycloak, while leaving already-percent-encoded sequences and every
other character untouched. This makes the value Keycloak saves already match the form it
would independently produce, so nothing downstream has anything left to normalize, and both
copies stay byte-identical through the whole round trip.

This fix is agnostic to exactly which hop (Keycloak's `KeycloakUriBuilder`, or something
else in the chain) performs the re-encoding — by removing the ambiguous, unencoded
characters at the source, there's nothing left for any downstream normalizer to change.

## Problem 2: Stale `session_state`/`iss` params can poison a later login's `redirect_uri`

### Symptom

A login that follows a previous login on the same page can fail with
`invalid_redirect_uri` even though nothing about the page's own query params changed.

Log entry for this failure mode (the stale `session_state` survives in the "Saved
redirectUri" from the earlier login, but is missing from the "redirectUri parameter" our
adapter reconstructs for the new one):

```
2026-07-02 09:24:19,656 +0000 [WARN] [org.keycloak.events] (executor-thread-74) rid= traceId=66a28f5f5dbc3e3fa8f03d741c9bcb03 type="CODE_TO_TOKEN_ERROR", realmId="1f758f7d-aad6-4f6e-942b-7b112dc31d11", realmName="Smartling", clientId="tms-dashboard-app", userId="cafe44da-6ce6-4229-9790-5cb71cc8e562", sessionId="0k-FhM3PauawCIsovwUYsNi3", ipAddress="52.70.162.138", error="invalid_redirect_uri", reason="Parameter 'redirect_uri' did not match originally saved redirect URI used in initial OIDC request. Saved redirectUri: https://dashboard.smartling.com/app/projects/4780a1673/dashboard/translator.htm?session_state=NApDQ_POmrQsYFKXJ_ZFKr14&auth_callback=1, redirectUri parameter: https://dashboard.smartling.com/app/projects/4780a1673/dashboard/translator.htm?auth_callback=1", grant_type="authorization_code", code_id="0k-FhM3PauawCIsovwUYsNi3", client_auth_method="client-secret"
```

### Root cause

`middleware/post-auth.js` builds a `cleanUrl` to redirect the browser to once login
succeeds, stripping the params Keycloak appended for the OAuth callback:

```js
delete urlParts.query.code;
delete urlParts.query.auth_callback;
delete urlParts.query.state;
```

This list is incomplete: it never deleted `session_state` or `iss`, even though both are
part of the same "Keycloak appended these to the callback, they were never part of the
app's real URL" category — and `reconstructRedirectUri`'s own blacklist
(`KEYCLOAK_CALLBACK_PARAMS = ['code', 'state', 'session_state', 'iss']`, added by the
original AUT-1461 fix) already treats them that way.

Because `cleanUrl` left `session_state`/`iss` in place, they persisted indefinitely in the
browser's address bar after a login that included them. If the user later triggered a new
login from that same page (e.g. session expiry), `forceLogin` built the new `redirect_uri`
from the raw page URL — which still carried the stale `session_state`/`iss` from the
previous login. Keycloak saved that value, stale params included. But on the new callback,
`reconstructRedirectUri` stripped `session_state`/`iss` again, assuming they were freshly
appended by *this* round of Keycloak's OIDC flow — producing a `redirect_uri` that no longer
matched Keycloak's saved copy.

### Fix

`cleanUrl` now also deletes `session_state` and `iss`, aligning it with
`KEYCLOAK_CALLBACK_PARAMS`, so these params can never persist in the browser's URL to seed a
future mismatch.
