### PR TITLE
AUT-1470 Strip stale error params and prioritize code over error in postAuth

### DIFF
--- a/middleware/post-auth.js
+++ b/middleware/post-auth.js
@@ -22,7 +22,7 @@ const URL = require('url');
 // be stripped when reconstructing it for the code-to-token exchange. Also used
 // by `forceLogin` in protect.js to strip stale copies of these params from the
 // current URL before it's captured as the redirect_uri for a fresh login.
-const KEYCLOAK_CALLBACK_PARAMS = ['code', 'state', 'session_state', 'iss'];
+const KEYCLOAK_CALLBACK_PARAMS = ['code', 'state', 'session_state', 'iss', 'error', 'error_description', 'error_uri'];
 
 // Reconstruct the redirect_uri from the incoming callback URL rather than
 // reading it from a single shared session key. The browser landed on this URL
@@ -59,7 +59,7 @@ module.exports = function (keycloak) {
       return next();
     }
 
-    if (request.query.error) {
+    if (request.query.error && !request.query.code) {
       return keycloak.accessDenied(request, response, next);
     }
 
@@ -72,11 +72,8 @@ module.exports = function (keycloak) {
           query: request.query
         };
 
-        delete urlParts.query.code;
         delete urlParts.query.auth_callback;
-        delete urlParts.query.state;
-        delete urlParts.query.session_state;
-        delete urlParts.query.iss;
+        KEYCLOAK_CALLBACK_PARAMS.forEach(param => delete urlParts.query[param]);
 
         let cleanUrl = URL.format(urlParts);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartling/keycloak-connect",
-  "version": "3.4.54",
+  "version": "3.4.55",
   "description": "Keycloak Connect Middleware",
   "homepage": "http://keycloak.org",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smartling/keycloak-connect",
-  "version": "3.4.53",
+  "version": "3.4.54",
   "description": "Keycloak Connect Middleware",
   "homepage": "http://keycloak.org",
   "main": "index.js",

--- a/test/unit/post-auth-middleware-test.js
+++ b/test/unit/post-auth-middleware-test.js
@@ -163,6 +163,101 @@ test('post-auth: strips session_state and iss, not just code/state/auth_callback
   t.end();
 });
 
+test('post-auth: strips error, error_description and error_uri from the reconstructed redirect_uri', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = postAuthMiddleware(keycloak);
+  const req = buildCallbackRequest({
+    originalUrl: '/app/dashboard?auth_callback=1&state=abc&code=xyz&session_state=sess&error=temporarily_unavailable&error_description=authentication_expired&error_uri=https%3A%2F%2Fkc.example%2Ferror',
+    query: {
+      auth_callback: '1',
+      state: 'abc',
+      code: 'xyz',
+      session_state: 'sess',
+      error: 'temporarily_unavailable',
+      error_description: 'authentication_expired',
+      error_uri: 'https://kc.example/error'
+    }
+  });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(
+    calls.getGrantFromCode[0].redirectUri,
+    'https://app.example/app/dashboard?auth_callback=1',
+    'stale error params are stripped from the reconstructed redirect_uri, matching what forceLogin sent'
+  );
+  t.end();
+});
+
+test('post-auth: attempts the code exchange when a stale error is present alongside a valid code', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = postAuthMiddleware(keycloak);
+  const req = buildCallbackRequest({
+    query: {
+      auth_callback: '1',
+      state: 'abc',
+      code: 'xyz',
+      session_state: 'sess',
+      error: 'temporarily_unavailable',
+      error_description: 'authentication_expired'
+    }
+  });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(calls.getGrantFromCode.length, 1, 'getGrantFromCode should run despite the stale error param');
+  t.equal(calls.accessDenied, 0, 'accessDenied should not be invoked when a valid code is present');
+  t.end();
+});
+
+test('post-auth: still denies access on error when no code is present', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = postAuthMiddleware(keycloak);
+  const req = buildCallbackRequest({
+    query: { auth_callback: '1', error: 'access_denied' }
+  });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(calls.accessDenied, 1, 'accessDenied should be invoked');
+  t.equal(calls.getGrantFromCode.length, 0, 'getGrantFromCode should not run without a code');
+  t.end();
+});
+
+test('post-auth: strips error, error_description and error_uri from the browser-facing redirect after a successful exchange', async t => {
+  const { keycloak } = buildKeycloakStub();
+  const middleware = postAuthMiddleware(keycloak);
+  const req = buildCallbackRequest({
+    path: '/app/account-jobs/',
+    query: {
+      filter: 'CURRENT_WORK',
+      auth_callback: '1',
+      state: 's1',
+      code: 'c1',
+      session_state: 'ss1',
+      iss: 'https://kc.example',
+      error: 'temporarily_unavailable',
+      error_description: 'authentication_expired'
+    }
+  });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  await new Promise(resolve => setImmediate(resolve));
+
+  t.equal(res._redirects.length, 1, 'one redirect issued');
+  t.equal(
+    res._redirects[0],
+    '/app/account-jobs/?filter=CURRENT_WORK',
+    'stale error params are stripped from the URL shown to the browser after a successful exchange'
+  );
+  t.end();
+});
+
 test('post-auth: includes port from the host header in the reconstructed redirect_uri', t => {
   const { keycloak, calls } = buildKeycloakStub();
   const middleware = postAuthMiddleware(keycloak);

--- a/test/unit/protect-middleware-test.js
+++ b/test/unit/protect-middleware-test.js
@@ -109,6 +109,24 @@ test('protect: leaves already-percent-encoded sequences untouched', t => {
   t.end();
 });
 
+test('protect: strips stale error, error_description and error_uri params before building redirect_uri', t => {
+  const { keycloak, calls } = buildKeycloakStub();
+  const middleware = protectMiddleware(keycloak);
+  const req = buildRequest({
+    originalUrl: '/app/dashboard?filter=CURRENT_WORK&error=temporarily_unavailable&error_description=authentication_expired&error_uri=https%3A%2F%2Fkc.example%2Ferror'
+  });
+  const res = buildResponse();
+
+  middleware(req, res, () => t.fail('next() should not be called'));
+
+  t.equal(
+    calls.loginUrl[0].redirectUrl,
+    'https://app.example/app/dashboard?filter=CURRENT_WORK&auth_callback=1',
+    'stale error params are stripped, leaving unrelated app params intact'
+  );
+  t.end();
+});
+
 test('protect: does not alter the pathname', t => {
   const { keycloak, calls } = buildKeycloakStub();
   const middleware = protectMiddleware(keycloak);


### PR DESCRIPTION
## Summary

Fixes a customer-reported infinite redirect loop caused by stale Keycloak error
params (`error=temporarily_unavailable&error_description=authentication_expired`)
surviving across login attempts.

### How the loop happens

1. **The trigger is a genuine Keycloak-side race**, not a bug in this adapter.
   Keycloak's `SessionCodeChecks` can hit `ALREADY_LOGGED_IN` when two login
   attempts race on the same auth session (e.g. multiple tabs, or a
   silent-reauth attempt overlapping a user-driven one). When that happens,
   Keycloak's `OIDCLoginProtocol.translateError()` maps it to
   `error=temporarily_unavailable&error_description=authentication_expired`
   and appends those params to the redirect back to the app, instead of a
   `code`. This event shows up in Keycloak's logs as `LOGIN_ERROR
   error="already_logged_in"`.

2. **`forceLogin` echoed those params forward.** The next time the app called
   `forceLogin` (protected route, still unauthenticated), it built the new
   `redirect_uri` it sends to Keycloak from whatever the *current* browser
   URL was — including the `error`/`error_description` left over from the
   previous failed attempt. So the fresh `/auth` request Keycloak received
   was for a `redirect_uri` that already had a failure baked into it.

3. **The next attempt succeeds, but on the poisoned URI.** Once Keycloak's
   session became valid again (the race was transient), this next login
   attempt succeeded and Keycloak appended `code=...` onto that *same*
   already-poisoned `redirect_uri`. The callback request the app received
   now carried a valid `code` **and** the stale `error`/`error_description`
   from the earlier failure, side by side in the same query string. This
   matches the customer log evidence directly: a `LOGIN` event immediately
   following a `LOGIN_ERROR error="already_logged_in"`, with the successful
   callback's URL still showing the old error params.

4. **`postAuth` threw the valid code away.** `postAuth`'s handling was
   `if (request.query.error) return accessDenied(...)` — checked
   unconditionally, before ever looking at `request.query.code`. So on that
   callback request, the presence of the stale `error` caused the valid
   `code` to be discarded and the request denied, even though a usable code
   was sitting right there. `getGrantFromCode` was never called, and no
   `CODE_TO_TOKEN` event appears in Keycloak's logs after the `LOGIN`.

5. **The client retried unconditionally, closing the loop.** The frontend
   (`account-level-jobs-frontend`) reacts to any 401/access-denied response
   with an unconditional `window.location.reload(true)` and has no backoff
   or circuit breaker. Each reload re-entered this same cycle: `forceLogin`
   copying forward the still-present error params, Keycloak returning a
   fresh `code` on top of them, `postAuth` denying it anyway. This produced
   the observed pattern of dozens of `LOGIN` events within ~1 second
   intervals with no successful `CODE_TO_TOKEN` in between, i.e. a
   self-sustaining redirect loop that never resolved on its own.

Fixing either link in this chain independently would have helped, but this PR
fixes both ends: it stops `forceLogin` from ever manufacturing a
`code`+stale-`error` request in the first place, and it makes `postAuth`
resilient to that combination if it occurs anyway.

See `REDIRECT-LOOP-INVESTIGATION.md` for the full evidence and root-cause
writeup attached to jira.

## Changes

**`middleware/post-auth.js`**
- Extended `KEYCLOAK_CALLBACK_PARAMS` to include `error`, `error_description`,
  `error_uri` alongside the existing `code`/`state`/`session_state`/`iss`.
  This single constant is shared by:
  - `forceLogin` (via the import in `middleware/protect.js`) — now strips
    stale error params from the current URL before capturing it as the new
    `redirect_uri`, so they can never be echoed into a future login attempt.
  - `reconstructRedirectUri` — strips the same params when rebuilding the
    `redirect_uri` for the code-to-token exchange, keeping it byte-identical
    to what `forceLogin` originally sent.
- Changed the early-exit condition from `if (request.query.error)` to
  `if (request.query.error && !request.query.code)`, so a valid `code` is
  used for the token exchange even if a stale `error` is also present on the
  same request. Scoped narrowly: any request where neither `code` nor
  `error` is present continues to fall through to `getGrantFromCode` and its
  existing rejection handling, unchanged from today.
- Refactored the post-exchange `cleanUrl` construction to strip params by
  iterating `KEYCLOAK_CALLBACK_PARAMS` instead of a hardcoded list of
  deletes, so `error`/`error_description`/`error_uri` are also removed from
  the URL shown to the browser after a successful login (previously only
  `code`/`state`/`session_state`/`iss` were removed there).

## What this fixes

- The specific documented loop: once `forceLogin` stops echoing stale error
  params forward, a `code` and stale `error` can no longer coexist on the
  same callback request through this code path, so the login attempt after
  a transient `ALREADY_LOGGED_IN` race completes normally.
- Leftover `error`/`error_description` params lingering in the browser's URL
  bar after a successful login.

## What this does NOT fix

- Genuinely permanent (non-transient) Keycloak errors — those still surface
  as `accessDenied` on every retry, since there's nothing to self-heal.
- The client-side amplification in `account-level-jobs-frontend`
  (unconditional `window.location.reload(true)` on 401, recursive polling
  with no circuit breaker) — that's a separate, unbounded-retry problem
  outside this adapter's scope. See "Open questions" in
  `REDIRECT-LOOP-INVESTIGATION.md`.
